### PR TITLE
Improvements to CANopen Magic CSV parsing

### DIFF
--- a/CANBUSAnalyzer/CANBUSAnalyzer.csproj
+++ b/CANBUSAnalyzer/CANBUSAnalyzer.csproj
@@ -96,6 +96,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="BindableTwoDArray.cs" />
+    <Compile Include="CSVParser.cs" />
     <Compile Include="Model3Packets.cs" />
     <Compile Include="ModelSPackets.cs" />
     <Compile Include="ListElement.cs" />

--- a/CANBUSAnalyzer/CANBUSAnalyzer.csproj.user
+++ b/CANBUSAnalyzer/CANBUSAnalyzer.csproj.user
@@ -9,7 +9,7 @@
     <ErrorReportUrlHistory />
     <FallbackCulture>en-US</FallbackCulture>
     <VerifyUploadedFiles>false</VerifyUploadedFiles>
-    <ProjectView>ProjectFiles</ProjectView>
+    <ProjectView>ShowAllFiles</ProjectView>
   </PropertyGroup>
   <PropertyGroup>
     <EnableSecurityDebugging>false</EnableSecurityDebugging>

--- a/CANBUSAnalyzer/CANBUSAnalyzer.csproj.user
+++ b/CANBUSAnalyzer/CANBUSAnalyzer.csproj.user
@@ -9,6 +9,7 @@
     <ErrorReportUrlHistory />
     <FallbackCulture>en-US</FallbackCulture>
     <VerifyUploadedFiles>false</VerifyUploadedFiles>
+    <ProjectView>ProjectFiles</ProjectView>
   </PropertyGroup>
   <PropertyGroup>
     <EnableSecurityDebugging>false</EnableSecurityDebugging>

--- a/CANBUSAnalyzer/CSVParser.cs
+++ b/CANBUSAnalyzer/CSVParser.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CANBUS
+{
+    // LATER: If needed, refactor to support delimited formats other than CANopen Magic
+    class CSVParser
+    {
+        private const int MinColumns = 16;
+        private static class ColumnIndex
+        {
+            public const int ID = 5;
+        }
+
+        public string Parse(string rawLine)
+        {
+            string formattedLine = null;
+            if (!string.IsNullOrEmpty(rawLine))
+            {
+                string[] split = rawLine.Split(',');
+                
+                // Ensure we have the expected number of columns
+                if (split.Length >= MinColumns)
+                {
+                    // Raw data is assumed to be in the final array element
+                    formattedLine = split[ColumnIndex.ID] + " " + split[split.Length - 1];
+                    formattedLine = formattedLine.Replace("\"", string.Empty).Replace(" ", string.Empty).Replace("0x", string.Empty);
+                }
+            }
+
+            return formattedLine;
+        }
+    }
+}

--- a/CANBUSAnalyzer/CSVParser.cs
+++ b/CANBUSAnalyzer/CSVParser.cs
@@ -6,7 +6,9 @@ using System.Threading.Tasks;
 
 namespace CANBUS
 {
-    // LATER: If needed, refactor to support delimited formats other than CANopen Magic
+    /// <summary>
+    /// Helps parse CANopen Magic CSV files. A stop-gap measure until the more robust log parsers in CANTools are integrated.
+    /// </summary>
     class CSVParser
     {
         private const int MinColumns = 16;
@@ -21,13 +23,17 @@ namespace CANBUS
             if (!string.IsNullOrEmpty(rawLine))
             {
                 string[] split = rawLine.Split(',');
-                
+
                 // Ensure we have the expected number of columns
                 if (split.Length >= MinColumns)
                 {
                     // Raw data is assumed to be in the final array element
                     formattedLine = split[ColumnIndex.ID] + " " + split[split.Length - 1];
                     formattedLine = formattedLine.Replace("\"", string.Empty).Replace(" ", string.Empty).Replace("0x", string.Empty);
+
+                    //// Sanity check
+                    //if ((formattedLine.Length <= 3 || formattedLine.Length > 26) && split[6] != @"""E""")
+                    //    Console.WriteLine("Unexpected data length:" + formattedLine.Length);
                 }
             }
 

--- a/CANBUSAnalyzer/MainWindow.xaml.cs
+++ b/CANBUSAnalyzer/MainWindow.xaml.cs
@@ -48,6 +48,7 @@ namespace CANBUS
     private string currentTitle;
     private bool isCSV;
     private Thread thread;
+    private CSVParser csvParser;
 
     BindableTwoDArray<char> MyBindableTwoDArray { get; set; }
 
@@ -131,6 +132,8 @@ namespace CANBUS
       currentLogSize = f.Length;
       currentTitle = Title;
       isCSV = currentLogFile.ToUpper().EndsWith(".CSV");
+      if (isCSV)
+         csvParser = new CSVParser();
       //runningTasks.Clear();
       timer?.Dispose();
       timer = null;
@@ -179,18 +182,14 @@ namespace CANBUS
           run = false;
         }
 
+        if (isCSV && csvParser != null)
+        {
+            line = csvParser.Parse(line);
+        }
+
         if (line == null)
         {
           return;
-        }
-
-        if (isCSV)
-        {
-          var split = line.Split(',');
-          line = split[5] + " " + split[15];
-          line = line.Replace("\"", "");
-          line = line.Replace(" ", "");
-          line = line.Replace("0x", "");
         }
 
         bool knownPacket;


### PR DESCRIPTION
This update does the following:

- Moves the logic for parsing CANopen Magic CSV files into its own class (CSVParser). 
- Addresses #10 by looking for "Data Raw" in the last split array value, rather than array element 15. This provides a quick workaround for the case where "Data Text" contains a comma.
- Adds some basic data-format checks on each CSV line (empty lines, expected number of split values) to avoid unnecessary exceptions. This improves performance (packets/sec) by about 40%.

These changes are only intended as stop-gap measures until we integrate the more robust and diverse log-parsing capabilities found in CANTools.