### PR TITLE
Quick-and-dirty Support for Importing Vector ASCII Logs

### DIFF
--- a/CANBUSAnalyzer/CANBUSAnalyzer.csproj
+++ b/CANBUSAnalyzer/CANBUSAnalyzer.csproj
@@ -97,6 +97,7 @@
     </ApplicationDefinition>
     <Compile Include="BindableTwoDArray.cs" />
     <Compile Include="CSVParser.cs" />
+    <Compile Include="ICANLogParser.cs" />
     <Compile Include="Model3Packets.cs" />
     <Compile Include="ModelSPackets.cs" />
     <Compile Include="ListElement.cs" />
@@ -104,6 +105,7 @@
     <Compile Include="Parser.cs" />
     <Compile Include="StringWithNotify.cs" />
     <Compile Include="Value.cs" />
+    <Compile Include="VectorASCParser.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/CANBUSAnalyzer/CANBUSAnalyzer.csproj
+++ b/CANBUSAnalyzer/CANBUSAnalyzer.csproj
@@ -96,6 +96,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="BindableTwoDArray.cs" />
+    <Compile Include="CSVParser.cs" />
     <Compile Include="Model3Packets.cs" />
     <Compile Include="ModelSPackets.cs" />
     <Compile Include="ListElement.cs" />

--- a/CANBUSAnalyzer/CANBUSAnalyzer.csproj.user
+++ b/CANBUSAnalyzer/CANBUSAnalyzer.csproj.user
@@ -9,7 +9,7 @@
     <ErrorReportUrlHistory />
     <FallbackCulture>en-US</FallbackCulture>
     <VerifyUploadedFiles>false</VerifyUploadedFiles>
-    <ProjectView>ProjectFiles</ProjectView>
+    <ProjectView>ShowAllFiles</ProjectView>
   </PropertyGroup>
   <PropertyGroup>
     <EnableSecurityDebugging>false</EnableSecurityDebugging>

--- a/CANBUSAnalyzer/CANBUSAnalyzer.csproj.user
+++ b/CANBUSAnalyzer/CANBUSAnalyzer.csproj.user
@@ -9,6 +9,7 @@
     <ErrorReportUrlHistory />
     <FallbackCulture>en-US</FallbackCulture>
     <VerifyUploadedFiles>false</VerifyUploadedFiles>
+    <ProjectView>ProjectFiles</ProjectView>
   </PropertyGroup>
   <PropertyGroup>
     <EnableSecurityDebugging>false</EnableSecurityDebugging>

--- a/CANBUSAnalyzer/CSVParser.cs
+++ b/CANBUSAnalyzer/CSVParser.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CANBUS
+{
+    // LATER: If needed, refactor to support delimited formats other than CANopen Magic
+    class CSVParser
+    {
+        private const int MinColumns = 16;
+        private static class ColumnIndex
+        {
+            public const int ID = 5;
+        }
+
+        public string Parse(string rawLine)
+        {
+            string formattedLine = null;
+            if (!string.IsNullOrEmpty(rawLine))
+            {
+                string[] split = rawLine.Split(',');
+                
+                // Ensure we have the expected number of columns
+                if (split.Length >= MinColumns)
+                {
+                    // Raw data is assumed to be in the final array element
+                    formattedLine = split[ColumnIndex.ID] + " " + split[split.Length - 1];
+                    formattedLine = formattedLine.Replace("\"", string.Empty).Replace(" ", string.Empty).Replace("0x", string.Empty);
+                }
+            }
+
+            return formattedLine;
+        }
+    }
+}

--- a/CANBUSAnalyzer/CSVParser.cs
+++ b/CANBUSAnalyzer/CSVParser.cs
@@ -6,7 +6,9 @@ using System.Threading.Tasks;
 
 namespace CANBUS
 {
-    // LATER: If needed, refactor to support delimited formats other than CANopen Magic
+    /// <summary>
+    /// Helps parse CANopen Magic CSV files. A stop-gap measure until the more robust log parsers in CANTools are integrated.
+    /// </summary>
     class CSVParser
     {
         private const int MinColumns = 16;
@@ -21,13 +23,17 @@ namespace CANBUS
             if (!string.IsNullOrEmpty(rawLine))
             {
                 string[] split = rawLine.Split(',');
-                
+
                 // Ensure we have the expected number of columns
                 if (split.Length >= MinColumns)
                 {
                     // Raw data is assumed to be in the final array element
                     formattedLine = split[ColumnIndex.ID] + " " + split[split.Length - 1];
                     formattedLine = formattedLine.Replace("\"", string.Empty).Replace(" ", string.Empty).Replace("0x", string.Empty);
+
+                    //// Sanity check
+                    //if ((formattedLine.Length <= 3 || formattedLine.Length > 26) && split[6] != @"""E""")
+                    //    Console.WriteLine("Unexpected data length:" + formattedLine.Length);
                 }
             }
 

--- a/CANBUSAnalyzer/CSVParser.cs
+++ b/CANBUSAnalyzer/CSVParser.cs
@@ -39,7 +39,5 @@ namespace CANBUS
 
             return formattedLine;
         }
-
-
     }
 }

--- a/CANBUSAnalyzer/CSVParser.cs
+++ b/CANBUSAnalyzer/CSVParser.cs
@@ -9,7 +9,7 @@ namespace CANBUS
     /// <summary>
     /// Helps parse CANopen Magic CSV files. A stop-gap measure until the more robust log parsers in CANTools are integrated.
     /// </summary>
-    class CSVParser
+    class CSVParser : ICANLogParser
     {
         private const int MinColumns = 16;
         private static class ColumnIndex
@@ -17,7 +17,7 @@ namespace CANBUS
             public const int ID = 5;
         }
 
-        public string Parse(string rawLine)
+        public string ParseLine(string rawLine)
         {
             string formattedLine = null;
             if (!string.IsNullOrEmpty(rawLine))
@@ -28,7 +28,7 @@ namespace CANBUS
                 if (split.Length >= MinColumns)
                 {
                     // Raw data is assumed to be in the final array element
-                    formattedLine = split[ColumnIndex.ID] + " " + split[split.Length - 1];
+                    formattedLine = split[ColumnIndex.ID] + split[split.Length - 1];
                     formattedLine = formattedLine.Replace("\"", string.Empty).Replace(" ", string.Empty).Replace("0x", string.Empty);
 
                     //// Sanity check
@@ -39,5 +39,7 @@ namespace CANBUS
 
             return formattedLine;
         }
+
+
     }
 }

--- a/CANBUSAnalyzer/ICANLogParser.cs
+++ b/CANBUSAnalyzer/ICANLogParser.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CANBUS
+{
+    interface ICANLogParser
+    {
+        string ParseLine(string rawLine);
+    }
+}

--- a/CANBUSAnalyzer/MainWindow.xaml.cs
+++ b/CANBUSAnalyzer/MainWindow.xaml.cs
@@ -48,6 +48,7 @@ namespace CANBUS
     private string currentTitle;
     private bool isCSV;
     private Thread thread;
+    private CSVParser csvParser;
 
     BindableTwoDArray<char> MyBindableTwoDArray { get; set; }
 
@@ -131,6 +132,8 @@ namespace CANBUS
       currentLogSize = f.Length;
       currentTitle = Title;
       isCSV = currentLogFile.ToUpper().EndsWith(".CSV");
+      if (isCSV)
+         csvParser = new CSVParser();
       //runningTasks.Clear();
       timer?.Dispose();
       timer = null;
@@ -179,18 +182,14 @@ namespace CANBUS
           run = false;
         }
 
+        if (isCSV && csvParser != null)
+        {
+            line = csvParser.Parse(line);
+        }
+
         if (line == null)
         {
           return;
-        }
-
-        if (isCSV)
-        {
-          var split = line.Split(',');
-          line = split[5] + " " + split[15];
-          line = line.Replace("\"", "");
-          line = line.Replace(" ", "");
-          line = line.Replace("0x", "");
         }
 
         bool knownPacket;

--- a/CANBUSAnalyzer/VectorASCParser.cs
+++ b/CANBUSAnalyzer/VectorASCParser.cs
@@ -26,7 +26,6 @@ namespace CANBUS
 
         public VectorASCParser()
         {
-            // Borrowed from CANTools
             regexLine = new Regex(@"^(\s+(?<Data>[^ ]+))+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
         }
 

--- a/CANBUSAnalyzer/VectorASCParser.cs
+++ b/CANBUSAnalyzer/VectorASCParser.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace CANBUS
+{
+    class VectorASCParser : ICANLogParser
+    {
+        private const int MinColumns = 7;
+        private const int IDLength = 3;
+        private const int ByteLength = 2;
+
+        private static class ColumnIndex
+        {
+            public const int ID = 2;
+            public const int DataLength = 5;
+            public const int FirstByte = 6;
+        }
+
+        private Regex regexLine;
+
+
+        public VectorASCParser()
+        {
+            // Borrowed from CANTools
+            regexLine = new Regex(@"^(\s+(?<Data>[^ ]+))+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        }
+
+        public string ParseLine(string rawLine)
+        {
+            string formattedLine = null;
+            if (!string.IsNullOrEmpty(rawLine))
+            {
+                Match m = regexLine.Match(rawLine);
+                
+                // Ensure we have the expected number of columns
+                if (m.Success && m.Groups["Data"].Captures.Count >= MinColumns)
+                {
+                    CaptureCollection capData = m.Groups["Data"].Captures;
+
+                    // Ensure that this is a valid (non-error) frame
+                    if (capData[2].Value.Length == IDLength && int.TryParse(capData[5].Value, out int dataLength))
+                    {
+                        // Start with the message ID
+                        formattedLine = capData[ColumnIndex.ID].Value;
+
+                        // Append message data
+                        for (int i = ColumnIndex.FirstByte; i < ColumnIndex.FirstByte + dataLength && i < capData.Count; i++)
+                        {
+                            // Sanity check
+                            Debug.Assert(capData[i].Value.Length == ByteLength);
+
+                            // Add to formatted data
+                            formattedLine += capData[i].Value;
+                        }
+                    }
+
+                }
+            }
+
+            return formattedLine;
+        }
+    }
+}


### PR DESCRIPTION
Similar to the CANopen Magic CSV parser, I've implemented a quick-and-dirty log-reader for the Vector ASCII format that JWardell provided. This log-reader will be used whenever an ".asc" file is loaded.

This reader will eventually be superseded by a more robust one based on CANTools, at which point I'll close out Issue #11. For now, though, this version should work well enough to allow folks to analyze Vector logs.

(FWIW: I created the branch for this PR from the completed version of the PR #15 branch, so it includes the same commits. Hopefully I didn't mess anything up by doing that... still learning the ropes here. :-) )