### PR TITLE
StringWithNotify Count starts at 1 instead of 0

### DIFF
--- a/CANBUSAnalyzer/StringWithNotify.cs
+++ b/CANBUSAnalyzer/StringWithNotify.cs
@@ -10,6 +10,7 @@ namespace CANBUS
     {
       _pid = pid;
       _str = s;
+      _count = 1;
       parser = p;
       parser.packets.TryGetValue(pid, out packet);
       mainWindow = mainwindow;


### PR DESCRIPTION
One more quick change: I noticed that the packet counts in the UI start at 0, rather than 1. That is, if there's a particular message ID that only appears once during a capture session, its count will be displayed as 0, rather than 1. 

This update changes StringWithNotify so that the "Count" property is initialized to 1 in the constructor. 