### PR TITLE
Packet Definitions Mode dropdown

### DIFF
--- a/CANBUSAnalyzer/CANBUSAnalyzer.csproj
+++ b/CANBUSAnalyzer/CANBUSAnalyzer.csproj
@@ -102,6 +102,7 @@
     <Compile Include="ModelSPackets.cs" />
     <Compile Include="ListElement.cs" />
     <Compile Include="Packet.cs" />
+    <Compile Include="PacketDefinitions.cs" />
     <Compile Include="Parser.cs" />
     <Compile Include="StringWithNotify.cs" />
     <Compile Include="Value.cs" />

--- a/CANBUSAnalyzer/MainWindow.xaml
+++ b/CANBUSAnalyzer/MainWindow.xaml
@@ -20,8 +20,29 @@
             <ColumnDefinition Width="404*"/>
         </Grid.ColumnDefinitions>
         <TextBox x:Name="KeywordTextBox" Height="23" Margin="10,10,10,0" TextWrapping="Wrap" Text="VIN: " VerticalAlignment="Top"/>
-        <Button Content="Load" HorizontalAlignment="Left" Margin="28,10,0,0" VerticalAlignment="Top" Width="75" Click="Button_Click_Load" Grid.Column="1" Height="20"/>
-        <Button Content="Stop" Grid.Column="1" HorizontalAlignment="Left" Margin="154,10,0,0" VerticalAlignment="Top" Width="29" Click="Button_Click_Stop" Height="20"/>
+        <TextBox x:Name="BatterySerialBox" Height="23" Margin="10,38,10,0" TextWrapping="Wrap" Text="Battery serial number:" VerticalAlignment="Top"/>
+        <TextBox x:Name="FirmwareBox" Height="23" Margin="10,66,10,0" TextWrapping="Wrap" Text="Firmware version:" VerticalAlignment="Top"/>
+
+        <WrapPanel Grid.Column="1" Margin="4,0,0,0" Grid.ColumnSpan="3" >
+            <Button Content="Load" Margin="6,10,0,0" Width="75" Height="20" Click="Button_Click_Load" />
+            <Button Content="&gt;" Margin="6,10,0,0" Width="40" Height="20" Click="Button_Click_Left" />
+            <Button Content="Stop" Margin="6,10,0,0" Width="40" Height="20" Click="Button_Click_Stop" />
+            <Button x:Name="PrevLog" Content="&lt;&lt;" Margin="6,10,0,0" Width="40" Height="20" Click="Button_Click_PrevtLog" />
+            <Button x:Name="NextLog" Content="&gt;&gt;" Margin="6,10,0,0" Width="40" Height="20" Click="Button_Click_NextLog" />
+
+            <Button x:Name="Color" Content="Color Me!" Margin="24,10,0,0" Width="76" Height="20" Click="Button_Click_Color" />
+            <Button x:Name="InterpretAs" Content="Interpret as" Margin="6,10,0,0" Width="75" Height="20" Click="Button_Click_InterpretAs" />
+            <Button x:Name="CopyIDButton" Content="Copy ID" Margin="6,10,0,0" Width="75" Height="20" Click="Button_Click_CopyID" />
+
+            <Button Content="as byte" Margin="24,10,0,0" Width="75" Height="20" Click="Button_Click_AsByte" />
+            <Button Content="as word" Margin="6,10,0,0" Width="75" Height="20" Click="Button_Click_AsWord" />
+            <Button Content="as int" Margin="6,10,0,0" Width="75" Height="20" Click="Button_Click_AsInt" />
+            <Button Content="Delete" Margin="6,10,0,0" Width="75" Height="20" Click="Button_Click_Delete" />
+            <Button Content="as temps" Margin="6,10,0,0" Width="75" Height="20" Click="Button_Click_AsTemps" />
+
+            <ComboBox Name="PacketMode" Height="23" Margin="6,10,0,0" Width="150" SelectionChanged="PacketMode_SelectionChanged" />
+        </WrapPanel>
+
         <DataGrid x:Name="PathList" Margin="10,94,10,10" ScrollViewer.HorizontalScrollBarVisibility="Disabled" AutoGenerateColumns="False" FontFamily="Courier New" SelectionChanged="PathList_SelectionChanged" PreviewKeyDown="PathList_KeyDown" Grid.RowSpan="2">
             <DataGrid.Columns>
                 <!--<DataGridTextColumn Binding="{Binding Length, Mode=OneWay, IsAsync=True}"/>-->
@@ -36,11 +57,9 @@
         </DataGrid>
         <StackPanel Grid.Column="3" Margin="8,38,10,10" Orientation="Vertical" Grid.RowSpan="2"/>
 
-        <Button x:Name="Color" Content="ColorMe!" Grid.Column="2" HorizontalAlignment="Left" Margin="43,10,0,0" VerticalAlignment="Top" Width="76" Click="Button_Click_Color" Height="20"/>
-        <Button Content="&gt;" Grid.Column="1" HorizontalAlignment="Left" Margin="108,10,0,0" VerticalAlignment="Top" Width="41" Click="Button_Click_Left" Height="20"/>
-        <Button Content="Interpret as" Grid.Column="2" Margin="118,10,0,0" VerticalAlignment="Top" Click="Button_Click_InterpretAs" HorizontalAlignment="Left" Width="75" Height="20"/>
-        <Button x:Name="CopyIDButton" Content="Copy ID" Grid.Column="2" HorizontalAlignment="Left" Margin="198,10,0,0" VerticalAlignment="Top" Width="75" Click="Button_Click_CopyID" Height="20"/>
-        <TabControl Margin="10,38,10,10" Grid.ColumnSpan="3" Grid.RowSpan="2" Grid.Column="1">
+        <GridSplitter Grid.Column="1" HorizontalAlignment="Left" Margin="0,10" Width="5" Grid.RowSpan="2"/>
+
+        <TabControl Margin="10,72,10,10" Grid.ColumnSpan="3" Grid.RowSpan="2" Grid.Column="1">
             <TabItem Header="Packets">
                 <Grid Background="#FFE5E5E5">
                     <DataGrid x:Name="AnalyzeResults" Margin="10,44,10,0" IsReadOnly="True" AutoGenerateColumns="True" MouseDoubleClick="HitsDataGrid_MouseDoubleClick" SelectionChanged="HitsDataGrid_SelectionChanged" ClipboardCopyMode="IncludeHeader"/>
@@ -79,15 +98,5 @@
                 </Grid>
             </TabItem>
         </TabControl>
-        <Button Content="as byte" Grid.Column="3" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="75" Click="Button_Click_AsByte" Height="20"/>
-        <Button Content="as word" Grid.Column="3" HorizontalAlignment="Left" Margin="90,10,0,0" VerticalAlignment="Top" Width="75" Click="Button_Click_AsWord" Height="20"/>
-        <Button Content="as int" Grid.Column="3" HorizontalAlignment="Left" Margin="170,10,0,0" VerticalAlignment="Top" Width="75" Click="Button_Click_AsInt" Height="20"/>
-        <Button Content="Delete" Grid.Column="3" HorizontalAlignment="Left" Margin="250,9,0,0" VerticalAlignment="Top" Width="75" Click="Button_Click_Delete" Height="20"/>
-        <GridSplitter Grid.Column="1" HorizontalAlignment="Left" Margin="0,10" Width="5" Grid.RowSpan="2"/>
-        <Button x:Name="NextLog" Content="&gt;&gt;" Grid.Column="1" HorizontalAlignment="Left" Margin="222,10,0,0" VerticalAlignment="Top" Width="31" Height="20" Click="Button_Click_NextLog"/>
-        <Button x:Name="PrevLog" Content="&lt;&lt;" Grid.Column="1" HorizontalAlignment="Left" Margin="191,10,0,0" VerticalAlignment="Top" Width="31" Click="Button_Click_PrevtLog" Height="20"/>
-        <Button Content="as temps" Grid.Column="3" HorizontalAlignment="Left" Margin="330,9,0,0" VerticalAlignment="Top" Width="75" Click="Button_Click_AsTemps" Height="20"/>
-        <TextBox x:Name="BatterySerialBox" Height="23" Margin="10,38,10,0" TextWrapping="Wrap" Text="Battery serial number:" VerticalAlignment="Top"/>
-        <TextBox x:Name="FirmwareBox" Height="23" Margin="10,66,10,0" TextWrapping="Wrap" Text="Firmware version:" VerticalAlignment="Top"/>
     </Grid>
 </Window>

--- a/CANBUSAnalyzer/MainWindow.xaml.cs
+++ b/CANBUSAnalyzer/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -63,9 +64,8 @@ namespace CANBUS
     {
       InitializeComponent();
       MyBindableTwoDArray = new BindableTwoDArray<char>(8, 8);
-      PathList.ItemsSource = runningTasks;
-      parser = new ModelSPackets();
-      //parser = new Model3Packets();
+      PathList.ItemsSource = runningTasks;       
+      PopulateDropdown(PacketMode, PacketDefinitions.GetAll(), "Source", "Name");
       HitsDataGrid.ItemsSource = parser.items;
       //HitsDataGrid.DataContext = parser.items;
       stopwatch = new Stopwatch();
@@ -716,6 +716,37 @@ namespace CANBUS
       run = false;
       timer?.Dispose();
       timer = null;
+    }
+
+    private void PacketMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (PacketMode.SelectedItem != null)
+        {
+            PacketDefinitions.DefinitionSource selectedDefs = (PacketDefinitions.DefinitionSource)PacketMode.SelectedValue;
+
+            // Mode change only allowed while not running
+            if (!run)
+            {
+                // LATER: Support DBC file selection. Better yet, put a dialog in front of "Load" where you can
+                //        select your input file, packet mode, and DBC file (if applicable)
+                parser = Parser.FromSource(selectedDefs);
+            }
+            else if (parser != null && parser.Definitions.Source != selectedDefs && PacketMode.Tag == null)
+            {
+                PacketMode.Tag = "undo";
+                PacketMode.SelectedValue = parser.Definitions.Source;
+                PacketMode.Tag = null;
+                }
+            }
+    }
+
+        private void PopulateDropdown(ComboBox cmb, System.Collections.IEnumerable items, string valueMember, string displayMember)
+    {
+        cmb.SelectedValuePath = valueMember;
+        cmb.DisplayMemberPath = displayMember;
+        cmb.ItemsSource = items;
+        cmb.UpdateLayout();
+        if (cmb.HasItems) cmb.SelectedIndex = 0;
     }
 
     private void HitsDataGrid_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/CANBUSAnalyzer/Model3Packets.cs
+++ b/CANBUSAnalyzer/Model3Packets.cs
@@ -18,6 +18,11 @@ namespace CANBUS {
     private int rrpm;
     private int drivePowerMax;
 
+    protected override PacketDefinitions GetPacketDefinitions()
+    {
+        return PacketDefinitions.GetSMTModel3();    
+    }
+
     public Model3Packets() : base() {
 
       /* tags:

--- a/CANBUSAnalyzer/ModelSPackets.cs
+++ b/CANBUSAnalyzer/ModelSPackets.cs
@@ -58,7 +58,10 @@ namespace CANBUS {
     private int inverterTemp;
     int numCells;
 
-
+    protected override PacketDefinitions GetPacketDefinitions()
+    {
+        return PacketDefinitions.GetSMTModelS();
+    }
 
     public ModelSPackets() : base() {
 

--- a/CANBUSAnalyzer/PacketDefinitions.cs
+++ b/CANBUSAnalyzer/PacketDefinitions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CANBUS
+{
+    public class PacketDefinitions
+    {
+        public enum DefinitionSource
+        {
+            Default = 0,
+            SMTModelS = 1,
+            SMTModel3 = 2,
+            DBCFile = 3
+        }
+
+        public DefinitionSource Source { get; private set; }
+        public string Name { get; private set; }
+
+        public PacketDefinitions(DefinitionSource source, string name)
+        {
+            Source = source;
+            Name = name;
+        }
+
+        public static IEnumerable<PacketDefinitions> GetAll()
+        {
+            return new PacketDefinitions[] { GetSMTModelS(), GetSMTModel3() };
+        }
+
+        public static PacketDefinitions GetSMTModelS()
+        {
+            return new PacketDefinitions(DefinitionSource.SMTModelS, "Model S (ScanMyTesla)");
+        }
+
+        public static PacketDefinitions GetSMTModel3()
+        {
+            return new PacketDefinitions(DefinitionSource.SMTModel3, "Model 3 (ScanMyTesla)");
+        }
+    }
+}


### PR DESCRIPTION
These changes partially address #18 by adding a dropdown list that allows the user to select between Model S and Model 3 ScanMyTesla packet definitions. This quick change should be of interest to anyone trying to use CANBUS-Analyzer to examine Model 3 capture sessions. Later, when we are ready to support DBC files, we can finish #18 by implementing a "Load" dialog/workflow that will allow users to select the input file, packet definition mode, and DBC file (if applicable).

Additionally... My WPF is a little rusty, but I've also tried to clean up the main toolbar by adding all of the buttons (and the new dropdown list) to a WrapPanel that spans the entire grid. This way, if the user resizes the main window (or the splitter), the toolbar buttons don't disappear.